### PR TITLE
Add question generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dataset.jsonl
+questions.jsonl

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-"# PyschBooks" 
+# PyschBooks
+
+This repository hosts several openly licensed psychology textbooks. Each book is stored in a separate directory containing a `content.md` file and images referenced from that text.
+
+## Dataset Preparation
+
+Use the script below to transform the markdown sources into a single machine readable dataset. The output is suitable for downstream tasks such as question generation.
+
+```bash
+python scripts/prepare_dataset.py
+```
+
+The script creates `dataset.jsonl` with one paragraph per line. Image references are retained in a list under the `images` key.
+
+## Question Generation
+
+An example rule-based question generator is provided. It scans the first 100 entries
+of `dataset.jsonl` and outputs rudimentary questions to `questions.jsonl`:
+
+```bash
+python scripts/generate_questions.py
+```
+
+This script is intentionally simple but demonstrates how the dataset can be used
+for automated content creation.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This repository hosts several openly licensed psychology textbooks. Each book is
 ## Dataset Preparation
 
 Use the script below to transform the markdown sources into a single machine readable dataset. The output is suitable for downstream tasks such as question generation.
+An optional `-o` argument lets you choose a custom output path.
 
 ```bash
-python scripts/prepare_dataset.py
+python scripts/prepare_dataset.py -o my_dataset.jsonl
 ```
 
 The script creates `dataset.jsonl` with one paragraph per line. Image references are retained in a list under the `images` key.

--- a/scripts/generate_questions.py
+++ b/scripts/generate_questions.py
@@ -1,0 +1,41 @@
+import json
+import os
+import re
+
+INPUT = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'dataset.jsonl')
+OUTPUT = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'questions.jsonl')
+
+SENTENCE_RE = re.compile(r'(?<=[.!?]) +')
+
+
+def create_question(text):
+    sentences = SENTENCE_RE.split(text)
+    for s in sentences:
+        s = s.strip()
+        # pattern: "X is ..." or "X are ..."
+        m = re.match(r'(.+?)\s+(is|are)\s+(.*)', s, flags=re.IGNORECASE)
+        if m and len(m.group(1).split()) <= 6:
+            subject = m.group(1).strip()
+            description = m.group(3).rstrip('.').strip()
+            q = f"What {m.group(2)} {subject}?"
+            a = f"{subject} {m.group(2)} {description}."
+            return q, a
+    return None, None
+
+
+def main():
+    with open(INPUT, 'r', encoding='utf-8') as in_f, open(OUTPUT, 'w', encoding='utf-8') as out_f:
+        for idx, line in enumerate(in_f):
+            if idx >= 100:
+                break
+            record = json.loads(line)
+            q, a = create_question(record['text'])
+            if q:
+                out_f.write(json.dumps({'book': record['book'],
+                                         'paragraph_index': record['paragraph_index'],
+                                         'question': q,
+                                         'answer': a}) + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -1,6 +1,7 @@
 import os
 import json
 import re
+import argparse
 
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 
@@ -74,7 +75,12 @@ def parse_markdown(text):
 
 
 def main():
-    with open(OUTPUT, 'w', encoding='utf-8') as out_f:
+    parser = argparse.ArgumentParser(description="Convert book markdown to JSONL")
+    parser.add_argument('-o', '--output', default=OUTPUT,
+                        help='Path for the output JSONL file')
+    args = parser.parse_args()
+
+    with open(args.output, 'w', encoding='utf-8') as out_f:
         for dataset in sorted(set(DATASETS)):
             for path in iter_content_files(dataset):
                 with open(path, 'r', encoding='utf-8') as f:

--- a/scripts/prepare_dataset.py
+++ b/scripts/prepare_dataset.py
@@ -1,0 +1,95 @@
+import os
+import json
+import re
+
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+
+DATASETS = [
+    d for d in os.listdir(ROOT_DIR)
+    if os.path.isdir(os.path.join(ROOT_DIR, d)) and os.path.exists(os.path.join(ROOT_DIR, d, 'content.md'))
+]
+
+# Some datasets use multiple content parts
+for d in os.listdir(ROOT_DIR):
+    if os.path.isdir(os.path.join(ROOT_DIR, d)):
+        part_files = [f for f in os.listdir(os.path.join(ROOT_DIR, d)) if f.startswith('content_part') and f.endswith('.md')]
+        if part_files:
+            DATASETS.append(d)
+
+OUTPUT = os.path.join(ROOT_DIR, 'dataset.jsonl')
+
+ENTRY_RE = re.compile(r'!\[(.*?)\]\((.*?)\)')
+
+
+def iter_content_files(dataset_dir):
+    """Yield all content markdown files in dataset directory."""
+    base = os.path.join(ROOT_DIR, dataset_dir)
+    parts = [f for f in os.listdir(base) if f.startswith('content') and f.endswith('.md')]
+    for part in sorted(parts):
+        yield os.path.join(base, part)
+
+
+def parse_markdown(text):
+    """Parse markdown content into paragraphs and image references."""
+    paragraphs = []
+    current = []
+    images = []
+
+    def flush():
+        nonlocal current, images
+        if current:
+            paragraphs.append({'text': ' '.join(current), 'images': images})
+            current = []
+            images = []
+
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            flush()
+            continue
+
+        m = ENTRY_RE.search(line)
+        if m:
+            images.append(m.group(2))
+            line = ENTRY_RE.sub('', line).strip()
+
+        if line.startswith('#'):
+            flush()
+            heading = line.lstrip('#').strip()
+            if heading:
+                paragraphs.append({'text': heading, 'images': []})
+            continue
+
+        if line.startswith('- '):
+            flush()
+            item = line[2:].strip()
+            if item:
+                paragraphs.append({'text': item, 'images': []})
+            continue
+
+        current.append(line)
+
+    flush()
+    return paragraphs
+
+
+def main():
+    with open(OUTPUT, 'w', encoding='utf-8') as out_f:
+        for dataset in sorted(set(DATASETS)):
+            for path in iter_content_files(dataset):
+                with open(path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                paragraphs = parse_markdown(content)
+                for idx, para in enumerate(paragraphs):
+                    record = {
+                        'book': dataset,
+                        'paragraph_index': idx,
+                        'text': para['text'],
+                    }
+                    if para['images']:
+                        record['images'] = para['images']
+                    out_f.write(json.dumps(record, ensure_ascii=False) + '\n')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- refine dataset parsing to better split headings and bullet lists
- add rule-based question generator to demonstrate usage
- document question generation and ignore the output file

## Testing
- `python scripts/prepare_dataset.py`
- `python scripts/generate_questions.py`


------
https://chatgpt.com/codex/tasks/task_e_686b4b89c46c832884b9720794f382a2