### PR TITLE
Improve question generation

### DIFF
--- a/scripts/generate_questions.py
+++ b/scripts/generate_questions.py
@@ -8,18 +8,63 @@ OUTPUT = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'questions.jso
 SENTENCE_RE = re.compile(r'(?<=[.!?]) +')
 
 
+def _invalid_sentence(sentence: str) -> bool:
+    """Return True if the sentence is unsuitable for question generation."""
+    s = sentence.strip()
+    if not s or len(s.split()) < 4:
+        return True
+    if any(c in s for c in [':', '"', "'", '?', '!', '@']):
+        return True
+    lower = s.lower()
+    bad_phrases = [
+        'taken from',
+        'based upon',
+        'creative commons',
+        'license',
+        'chapter',
+        'figure',
+        'table',
+        'openstax',
+        'pressbooks',
+        'http',
+        'thank',
+        'download',
+    ]
+    if any(p in lower for p in bad_phrases):
+        return True
+    if re.match(r'^[0-9]+[.)]', s):
+        return True
+    if re.search(r'\b(i|we|our|my|your|you)\b', lower):
+        return True
+    return False
+
+
 def create_question(text):
     sentences = SENTENCE_RE.split(text)
     for s in sentences:
         s = s.strip()
+        if _invalid_sentence(s):
+            continue
         # pattern: "X is ..." or "X are ..."
         m = re.match(r'(.+?)\s+(is|are)\s+(.*)', s, flags=re.IGNORECASE)
-        if m and len(m.group(1).split()) <= 6:
-            subject = m.group(1).strip()
-            description = m.group(3).rstrip('.').strip()
-            q = f"What {m.group(2)} {subject}?"
-            a = f"{subject} {m.group(2)} {description}."
-            return q, a
+        if not m:
+            continue
+        subject = m.group(1).strip()
+        description = m.group(3).rstrip('.').strip()
+        if len(subject.split()) > 6:
+            continue
+        if not re.match(r'^[A-Za-z][A-Za-z -]*$', subject):
+            continue
+        if subject.lower() in {
+            'i', 'we', 'you', 'he', 'she', 'it', 'they', 'there',
+            'this', 'that', 'these', 'those'
+        }:
+            continue
+        if len(description.split()) > 20:
+            continue
+        q = f"What {m.group(2)} {subject}?"
+        a = f"{subject} {m.group(2)} {description}."
+        return q, a
     return None, None
 
 


### PR DESCRIPTION
## Summary
- filter many more bad sentences when generating questions

## Testing
- `python scripts/prepare_dataset.py`
- `python scripts/generate_questions.py`
- `python train_tutor.py`
- `python interactive_tutor.py <<'EOF'
quit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_686f6db075c08328bafb9d0044c48ae3