### PR TITLE
Improve question generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,15 @@ python scripts/prepare_dataset.py -o my_dataset.jsonl
 After preparing the dataset you can build a simple tutor model and launch an interactive session.
 
 ```bash
-python scripts/generate_questions.py       # create questions.jsonl
+python scripts/generate_questions.py -i dataset.jsonl -o questions.jsonl \
+    -l 500        # create up to 500 questions
 python train_tutor.py                       # build tutor_model.json
 python interactive_tutor.py                 # start the tutor
 ```
+
+The question generator accepts optional `--input`, `--output`, and `--limit`
+flags. When omitted it looks for `dataset.jsonl` and writes `questions.jsonl`
+while processing up to 100 paragraphs.
 
 The tutor now assigns a concept to each question based on the subject of the prompt. During an interactive session your knowledge is updated per concept so you receive a mastery summary at the end.
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,11 @@
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from scripts.generate_questions import create_question
+
+def test_simple():
+    q, a = create_question("Memory is the process of storing information for later retrieval.")
+    assert q is not None
+    assert "Memory" in q
+    assert "process of storing" in a
+


### PR DESCRIPTION
## Summary
- skip heading-only paragraphs
- reject vague subjects and short descriptions
- support more definition patterns
- vary question stems to avoid repetition
- add a simple unit test for `create_question`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f722a0e688328a5d913e1f36bd445